### PR TITLE
Sad path roadtrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ end
 
 * In order to run the tests, run `bundle exec rspec` in the command line and you should have all passing tests.
 
-* Test coverage is at 100% with 54 passing tests.
-![simplecov](https://user-images.githubusercontent.com/7945439/104971567-680f1d00-59ac-11eb-99d3-afc0ba65605e.png)
+* Test coverage is at 100% with 55 passing tests.
+![Screen Shot 2021-01-19 at 3 11 15 PM](https://user-images.githubusercontent.com/7945439/105099252-9c481380-5a68-11eb-9338-354521fdcc62.png)
 
 ## API Endpoints
 

--- a/app/facades/weather_facade.rb
+++ b/app/facades/weather_facade.rb
@@ -21,15 +21,22 @@ class WeatherFacade
       trip
 
     else
-      hourly_weather = WeatherService.hourly_weather(city_coordinates)
-
       hours = (driving_time[0].to_f / 3600).round
 
-      trip[:temperature] = hourly_weather[:hourly][hours][:temp]
-      trip[:conditions] = hourly_weather[:hourly][hours][:weather].first[:description]
-      trip[:travel_time] = driving_time[1]
+      if hours <= 48
+        hourly_weather = WeatherService.hourly_weather(city_coordinates)
+        trip[:temperature] = hourly_weather[:hourly][hours][:temp]
+        trip[:conditions] = hourly_weather[:hourly][hours][:weather].first[:description]
+        trip[:travel_time] = driving_time[1]
 
-      trip
+      else
+        day = hours / 24
+        daily_weather = WeatherService.get_weather(city_coordinates)
+        trip[:temperature] = daily_weather[:daily][day][:temp][:day]
+        trip[:conditions] = daily_weather[:daily][day][:weather].first[:description]
+        trip[:travel_time] = driving_time[1]
+      end
     end
+    trip
   end
 end

--- a/app/services/directions_service.rb
+++ b/app/services/directions_service.rb
@@ -13,11 +13,10 @@ class DirectionsService
 
     body = JSON.parse(response.body, symbolize_names: true)
 
-    if body[:info][:statuscode] == 402
-      {
-        error: 'Impossible',
-        status: 400
-      }
+    impossible_error_codes = [601, 602, 603, 610, 402]
+
+    if impossible_error_codes.include?(body[:info][:statuscode]) || body[:route][:realTime] == 10000000
+      { error: 'Impossible', status: 400 }
     else
       body
     end

--- a/spec/requests/api/v1/road_trip_request_spec.rb
+++ b/spec/requests/api/v1/road_trip_request_spec.rb
@@ -105,4 +105,30 @@ describe "Road Trip API endpoint" do
     expect(attributes).to have_key(:weather_at_eta)
     expect(attributes[:weather_at_eta]).to eq(nil)
   end
+
+  it "returns weather even if trip length is greater than 48 hours" do
+    params = {
+      "origin": "Anchorage, AK",
+      "destination": "Tijuana, MX",
+      "api_key": "longspecialcodehere"
+      }
+
+    post "/api/v1/road_trip", headers: @headers, params: params.to_json
+
+    expect(response.status).to eq(200)
+
+    roadtrip = JSON.parse(response.body, symbolize_names: true)
+
+    attributes = roadtrip[:data][:attributes]
+
+    expect(attributes[:start_city]).to eq("Anchorage, AK")
+    expect(attributes[:end_city]).to eq("Tijuana, MX")
+    expect(attributes[:travel_time]).to be_a(String)
+    expect(attributes).to have_key(:weather_at_eta)
+    expect(attributes[:weather_at_eta]).to be_a(Hash)
+    expect(attributes[:weather_at_eta]).to have_key(:temperature)
+    expect(attributes[:weather_at_eta][:temperature]).to be_a(Float)
+    expect(attributes[:weather_at_eta]).to have_key(:conditions)
+    expect(attributes[:weather_at_eta][:conditions]).to be_a(String)
+  end
 end


### PR DESCRIPTION
This PR will:
- Display weather for trips longer than 48 hours.
- Give an error if any road along the route path is currently closed (see [realTime](https://developer.mapquest.com/documentation/directions-api/route/get/).
- Give an error for Invalid Location and other [Route/Optimized Route Call](https://developer.mapquest.com/documentation/directions-api/status-codes/) Location-based errors.

- [x] Happy Path Tested

- [x] Sad Path Tested

- [x] All Tests are passing

- [x] Updated README.md with added information

- closes #30 
- closes #36 